### PR TITLE
adding tagPrefix option

### DIFF
--- a/cmd/fresh-container/main.go
+++ b/cmd/fresh-container/main.go
@@ -92,6 +92,14 @@ $ fresh-container check --constraint ">= 1.5.0 < 1.6.0" "influxdb:1.5.0"
 						EnvVars: []string{"FRESH_CONTAINER_CHECK_OUTPUT"},
 						Value:   "text",
 					},
+					&cli.StringFlag{
+						Name:    "tagPrefix",
+						Aliases: []string{""},
+						Usage:   "Tag Prefix: use if the version tags have a prefix before the versioning infomation, i.e for Ubuntu-2021.10.3 use Ubuntu as a tag prefix",
+						EnvVars: []string{"FRESH_CONTAINER_TAG_PREFIX"},
+						Value:   "",
+					},
+					
 				},
 			},
 			{

--- a/internal/api/v1/check.go
+++ b/internal/api/v1/check.go
@@ -17,10 +17,11 @@ func (a *ApiServer) Check(w http.ResponseWriter, r *http.Request) {
 	log.WithFields(log.Fields{
 		"image":      vars["image"],
 		"constraint": vars["constraint"],
+		"tagPrefix": vars["tagPrefix"],
 		"host":       r.Host,
 	}).Debug("GET check")
 
-	image, err := fresh_container.NewImage(vars["image"])
+	image, err := fresh_container.NewImage(vars["image"],vars["tagPrefix"])
 	if err != nil {
 		ServeErrorAsJSON(w, http.StatusBadRequest, err)
 		return
@@ -50,13 +51,13 @@ func (a *ApiServer) Check(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = image.SetTagVersions(tags, true); err != nil {
+	if err = image.SetTagVersions(tags, vars["tagPrefix"], true); err != nil {
 		ServeErrorAsJSON(w, http.StatusInternalServerError, err)
 		return
 	}
 
-	evaluation, err := image.EvalUpgrade(vars["constraint"])
-	if err = image.SetTagVersions(tags, true); err != nil {
+	evaluation, err := image.EvalUpgrade(vars["constraint"],vars["tagPrefix"])
+	if err = image.SetTagVersions(tags, vars["tagPrefix"], true); err != nil {
 		ServeErrorAsJSON(w, http.StatusInternalServerError, err)
 		return
 	}

--- a/internal/workers/job_handler.go
+++ b/internal/workers/job_handler.go
@@ -8,8 +8,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (w *BackgroundWorker) ProcessJob(ctx context.Context, id, img, constraint string) error {
-	image, err := fresh_container.NewImage(img)
+func (w *BackgroundWorker) ProcessJob(ctx context.Context, id, img, constraint string, tagPrefix string) error {
+	image, err := fresh_container.NewImage(img, tagPrefix)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"id":         id,
@@ -21,7 +21,7 @@ func (w *BackgroundWorker) ProcessJob(ctx context.Context, id, img, constraint s
 	}
 
 	// reach to external registry to fetch tags
-	if err = image.FetchTags(ctx, w.config); err != nil {
+	if err = image.FetchTags(ctx, tagPrefix, w.config); err != nil {
 		log.WithFields(log.Fields{
 			"id":         id,
 			"image":      img,
@@ -54,12 +54,13 @@ func (w *BackgroundWorker) ProcessJob(ctx context.Context, id, img, constraint s
 		}).Debug("worker.ProcessJob")
 	}
 
-	evaluation, err := image.EvalUpgrade(constraint)
+	evaluation, err := image.EvalUpgrade(constraint, tagPrefix)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"id":         id,
 			"image":      img,
 			"constraint": constraint,
+			"tagPrefix":  tagPrefix,
 			"error":      err,
 		}).Error("worker.ProcessJob")
 		return err

--- a/pkg/fresh_container/client.go
+++ b/pkg/fresh_container/client.go
@@ -20,7 +20,7 @@ func NewClient(server string) Client {
 	}
 }
 
-func (c *Client) EvalUpgrade(image, constraint string) (RemoteEvaluationResponse, error) {
+func (c *Client) EvalUpgrade(image, constraint string, tagPrefix string) (RemoteEvaluationResponse, error) {
 	u, err := url.Parse(c.Server)
 	if err != nil {
 		return RemoteEvaluationResponse{}, err
@@ -30,6 +30,7 @@ func (c *Client) EvalUpgrade(image, constraint string) (RemoteEvaluationResponse
 	q := u.Query()
 	q.Add("image", image)
 	q.Add("constraint", constraint)
+	q.Add("tagPrefix", tagPrefix)
 	u.RawQuery = q.Encode()
 
 	resp, err := http.Get(u.String())
@@ -40,6 +41,7 @@ func (c *Client) EvalUpgrade(image, constraint string) (RemoteEvaluationResponse
 	log.WithFields(log.Fields{
 		"image":      image,
 		"constraint": constraint,
+		"tagPrefix": tagPrefix,
 		"resp-code":  resp.Status,
 		"headers":    resp.Header,
 	}).Debug("Remote evaluation response")

--- a/pkg/fresh_container/comparer.go
+++ b/pkg/fresh_container/comparer.go
@@ -2,10 +2,21 @@ package fresh_container
 
 import (
 	"github.com/blang/semver"
+	"strings"
+	"fmt"
 )
 
-func NextTag(curTag, constraint string, tags []string) (string, error) {
-	curVer, err := semver.Parse(curTag)
+func NextTag(curTag, constraint string, tagPrefix string, tags []string) (string, error) {
+	trimmedTag:=strings.TrimPrefix(curTag, tagPrefix)
+	if tagPrefix!="" && trimmedTag==curTag {
+		err:=fmt.Errorf(
+				"The current tag '%s' didn't start with the tag prefix '%s'.",
+				curTag,
+				tagPrefix)
+		return "", err
+	}
+
+	curVer, err := semver.Parse(trimmedTag)
 	if err != nil {
 		return "", err
 	}
@@ -15,17 +26,17 @@ func NextTag(curTag, constraint string, tags []string) (string, error) {
 		return "", err
 	}
 
-	versions, err := TagsToVersions(tags, false)
+	versions, err := TagsToVersions(tags, tagPrefix, false)
 	if err != nil {
 		return "", err
 	}
 
-	nextVer := NextVersion(curVer, constraintRange, versions)
+	nextVer := NextVersion(curVer, constraintRange, tagPrefix, versions)
 
 	return nextVer.String(), nil
 }
 
-func NextVersion(curVer semver.Version, constraintRange semver.Range, versions semver.Versions) semver.Version {
+func NextVersion(curVer semver.Version, constraintRange semver.Range, tagPrefix string, versions semver.Versions) semver.Version {
 	nextVer := curVer
 	for _, v := range versions {
 		if constraintRange(v) {

--- a/pkg/fresh_container/comparer_test.go
+++ b/pkg/fresh_container/comparer_test.go
@@ -5,21 +5,21 @@ import (
 )
 
 func TestNextReleaseInvalidConstraint(t *testing.T) {
-	_, err := NextTag("1.1", "> 1.0", []string{})
+	_, err := NextTag("1.1", "> 1.0", "", []string{})
 	if err == nil {
 		t.Error("Expected failure parsing invalid constraint")
 	}
 }
 
 func TestNextReleaseInvalidVersion(t *testing.T) {
-	_, err := NextTag("1.1", "> 1.1.0", []string{})
+	_, err := NextTag("1.1", "> 1.1.0",  "", []string{})
 	if err == nil {
 		t.Error("Expected failure parsing invalid version")
 	}
 }
 
 func TestNextReleaseInvalidVersions(t *testing.T) {
-	_, err := NextTag("1.1.0", "> 1.1.0", []string{"1.1"})
+	_, err := NextTag("1.1.0", "> 1.1.0", "",[]string{"1.1"})
 	if err == nil {
 		t.Error("Expected failure parsing invalid versions")
 	}
@@ -108,7 +108,7 @@ func TestNextTag(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		nextTag, err := NextTag(tc.CurTag, tc.Constraint, tc.Tags)
+		nextTag, err := NextTag(tc.CurTag, tc.Constraint, "", tc.Tags)
 		if err != nil {
 			t.Errorf("Unexpected error when handling test case %+v: %+v", tc, err)
 		}


### PR DESCRIPTION
Hi Flavio,

I ran into a case where the tag structure I was trying to catch was:   ubuntu-<semver#>   (see for ex zabbix/zabbix-agent)

Those tags were predictable but not parsable directly, so I added an optional tagPrefix argument.  If that argument is provided, only tags that start with that value are considered, and a valid semver is expected after the prefix..

The changes were more extensive than I had hoped, mostly to pass around that extra value everywhere..

Let me know if you have any questions, Thanks.