### PR TITLE
TagPrefix Deployment Bug Fixes

### DIFF
--- a/internal/api/v1/check.go
+++ b/internal/api/v1/check.go
@@ -14,14 +14,17 @@ import (
 func (a *ApiServer) Check(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
+	// tagPrefix is optional so have to retrieve it explicitely
+	tagPrefix := r.URL.Query().Get("tagPrefix")
+
 	log.WithFields(log.Fields{
 		"image":      vars["image"],
 		"constraint": vars["constraint"],
-		"tagPrefix":  vars["tagPrefix"],
+		"tagPrefix":  tagPrefix,
 		"host":       r.Host,
 	}).Debug("GET check")
 
-	image, err := fresh_container.NewImage(vars["image"], vars["tagPrefix"])
+	image, err := fresh_container.NewImage(vars["image"], tagPrefix)
 	if err != nil {
 		ServeErrorAsJSON(w, http.StatusBadRequest, err)
 		return
@@ -41,7 +44,7 @@ func (a *ApiServer) Check(w http.ResponseWriter, r *http.Request) {
 
 	if len(tags) == 0 {
 		// No tags - queue the job
-		id, err := a.backgroundWorker.AddJob(vars["image"], vars["constraint"], vars["tagPrefix"])
+		id, err := a.backgroundWorker.AddJob(vars["image"], vars["constraint"], tagPrefix)
 		if err != nil {
 			ServeErrorAsJSON(w, http.StatusInternalServerError, err)
 			return

--- a/internal/api/v1/check.go
+++ b/internal/api/v1/check.go
@@ -54,16 +54,13 @@ func (a *ApiServer) Check(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = image.SetTagVersions(tags, true); err != nil {
+	// prefixes have already been stripped since we got this from cache
+	if err = image.SetTagVersions(tags, true, true); err != nil {
 		ServeErrorAsJSON(w, http.StatusInternalServerError, err)
 		return
 	}
 
 	evaluation, err := image.EvalUpgrade(vars["constraint"])
-	if err = image.SetTagVersions(tags, true); err != nil {
-		ServeErrorAsJSON(w, http.StatusInternalServerError, err)
-		return
-	}
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)

--- a/internal/api/v1/server.go
+++ b/internal/api/v1/server.go
@@ -12,6 +12,8 @@ import (
 
 	gorilla_handlers "github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type ApiServer struct {
@@ -44,22 +46,13 @@ func (a *ApiServer) ListenAndServe() error {
 }
 
 func (a *ApiServer) initRoutes() {
-	a.router.
-		Path("/api/v1/check").
-		Methods("GET").
-		Queries(
-			"image", "{image}",
-			"constraint", "{constraint}",
-		).HandlerFunc(a.Check)
 
-	// Registering the handler twice seems to be the easiest way to have an option query
 	a.router.
 		Path("/api/v1/check").
 		Methods("GET").
 		Queries(
 			"image", "{image}",
 			"constraint", "{constraint}",
-			"tagPrefix", "{tagPrefix}",
 		).HandlerFunc(a.Check)
 
 	a.router.
@@ -81,7 +74,7 @@ func (a *ApiServer) initRoutes() {
 func ServeErrorAsJSON(w http.ResponseWriter, statusCode int, err error) error {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(statusCode)
-
+	log.Errorf("Encoutered error: %s", err)
 	msg := struct {
 		Error error
 	}{

--- a/internal/api/v1/server.go
+++ b/internal/api/v1/server.go
@@ -76,9 +76,9 @@ func ServeErrorAsJSON(w http.ResponseWriter, statusCode int, err error) error {
 	w.WriteHeader(statusCode)
 	log.Errorf("Encountered error: %s", err)
 	msg := struct {
-		Error error
+		Error string
 	}{
-		err,
+		fmt.Sprintf("%s", err),
 	}
 	return json.NewEncoder(w).Encode(msg)
 }

--- a/internal/api/v1/server.go
+++ b/internal/api/v1/server.go
@@ -74,7 +74,7 @@ func (a *ApiServer) initRoutes() {
 func ServeErrorAsJSON(w http.ResponseWriter, statusCode int, err error) error {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(statusCode)
-	log.Errorf("Encoutered error: %s", err)
+	log.Errorf("Encountered error: %s", err)
 	msg := struct {
 		Error error
 	}{

--- a/internal/db/evaluations.go
+++ b/internal/db/evaluations.go
@@ -3,22 +3,33 @@ package db
 import (
 	"fmt"
 	"time"
+	"strings"
 
 	badger "github.com/dgraph-io/badger/v2"
 )
 
-func (d *DB) SetEvaluation(id string, result []byte) error {
+func (d *DB) SetEvaluation(id string, result []byte, status string) error {
 	key := fmt.Sprintf("evaluations/%s", id)
 	return d.db.Update(func(txn *badger.Txn) error {
 		entry := badger.NewEntry([]byte(key), result).
 			WithTTL(time.Duration(d.config.CacheTTLHours) * time.Hour)
-		return txn.SetEntry(entry)
+		err := txn.SetEntry(entry)
+		if err == nil && status != "" {
+			key := fmt.Sprintf("evaluations-status/%s", id)
+			entry := badger.NewEntry([]byte(key), []byte(status)).
+				WithTTL(time.Duration(d.config.CacheTTLHours) * time.Hour)
+			err = txn.SetEntry(entry)
+		}
+		return err
 	})
 }
 
 func (d *DB) GetEvaluation(id string) (string, error) {
 	key := fmt.Sprintf("evaluations/%s", id)
+	statusKey := fmt.Sprintf("evaluations-status/%s", id)
 	var result string
+	var resultStatus string
+	var errStatus error
 
 	err := d.db.View(func(txn *badger.Txn) error {
 		item, err := txn.Get([]byte(key))
@@ -28,15 +39,37 @@ func (d *DB) GetEvaluation(id string) (string, error) {
 			}
 			return err
 		}
-
 		return item.Value(func(val []byte) error {
 			result = string(val)
 			return nil
 		})
 	})
 
+	if result != "" {
+		errStatus = d.db.View(func(txn *badger.Txn) error {
+			item, err := txn.Get([]byte(statusKey))
+			if err != nil {
+				if err == badger.ErrKeyNotFound {
+					return nil
+				} else {
+					return err
+				}
+			}
+			return item.Value(func(val []byte) error {
+				resultStatus = string(val)
+				return nil
+			})
+		})
+	}
+
 	if err != nil {
 		return "", err
+	}
+	if errStatus != nil {
+		return "", errStatus
+	}
+	if resultStatus != "" {
+		return "", fmt.Errorf("%s", strings.ReplaceAll(result, "\\", ""))
 	}
 
 	return result, nil

--- a/internal/db/evaluations.go
+++ b/internal/db/evaluations.go
@@ -2,8 +2,8 @@ package db
 
 import (
 	"fmt"
-	"time"
 	"strings"
+	"time"
 
 	badger "github.com/dgraph-io/badger/v2"
 )

--- a/internal/db/tags.go
+++ b/internal/db/tags.go
@@ -14,6 +14,9 @@ func (d *DB) GetImageTags(image fresh_container.Image) ([]string, error) {
 	var tags []string
 
 	err := d.db.View(func(txn *badger.Txn) error {
+		// adding the tag prefix add the end makes the cache per tag prefix, which is correct
+		// behavior.  Note that the version tags are stored without the prefix when there is one
+		// to make the semver code easier to run. 
 		item, err := txn.Get([]byte(image.FullNameWithoutTag() + image.TagPrefix))
 		if err != nil {
 			if err == badger.ErrKeyNotFound {

--- a/internal/db/tags.go
+++ b/internal/db/tags.go
@@ -14,7 +14,7 @@ func (d *DB) GetImageTags(image fresh_container.Image) ([]string, error) {
 	var tags []string
 
 	err := d.db.View(func(txn *badger.Txn) error {
-		item, err := txn.Get([]byte(image.FullNameWithoutTag()))
+		item, err := txn.Get([]byte(image.FullNameWithoutTag() + image.TagPrefix))
 		if err != nil {
 			if err == badger.ErrKeyNotFound {
 				return nil
@@ -55,7 +55,7 @@ func (d *DB) SetImageTags(image fresh_container.Image, tags []string) error {
 	}
 
 	return d.db.Update(func(txn *badger.Txn) error {
-		entry := badger.NewEntry([]byte(image.FullNameWithoutTag()), marshalledTags).
+		entry := badger.NewEntry([]byte(image.FullNameWithoutTag()+image.TagPrefix), marshalledTags).
 			WithTTL(time.Duration(d.config.CacheTTLHours) * time.Hour)
 		return txn.SetEntry(entry)
 	})

--- a/internal/db/tags.go
+++ b/internal/db/tags.go
@@ -16,7 +16,7 @@ func (d *DB) GetImageTags(image fresh_container.Image) ([]string, error) {
 	err := d.db.View(func(txn *badger.Txn) error {
 		// adding the tag prefix add the end makes the cache per tag prefix, which is correct
 		// behavior.  Note that the version tags are stored without the prefix when there is one
-		// to make the semver code easier to run. 
+		// to make the semver code easier to run.
 		item, err := txn.Get([]byte(image.FullNameWithoutTag() + image.TagPrefix))
 		if err != nil {
 			if err == badger.ErrKeyNotFound {
@@ -47,6 +47,10 @@ func (d *DB) GetImageTags(image fresh_container.Image) ([]string, error) {
 
 func (d *DB) SetImageTags(image fresh_container.Image, tags []string) error {
 	marshalledTags, err := json.Marshal(tags)
+	log.WithFields(log.Fields{
+		"image": image.FullNameWithoutTag(),
+		"tags":  tags,
+	}).Debug("db.SetImageTags")
 	if err != nil {
 		log.WithFields(log.Fields{
 			"image": image.FullNameWithoutTag(),

--- a/internal/workers/job_handler.go
+++ b/internal/workers/job_handler.go
@@ -5,31 +5,60 @@ import (
 
 	"context"
 	"encoding/json"
+	"fmt"
 	log "github.com/sirupsen/logrus"
+	"net/http"
 )
 
-func (w *BackgroundWorker) ProcessJob(ctx context.Context, id, img, constraint, tagPrefix string) error {
-	image, err := fresh_container.NewImage(img, tagPrefix)
-	if err != nil {
+func (w *BackgroundWorker) _handleError(ctx context.Context, tagPrefix string, id string, img string, constraint string, action string, err error) {
+	log.WithFields(log.Fields{
+		"action":     action,
+		"id":         id,
+		"image":      img,
+		"constraint": constraint,
+		"tagPrefix":  tagPrefix,
+		"error":      err,
+	}).Error("worker.ProcessJob")
+	msg := struct {
+		Error string
+	}{
+		fmt.Sprint(err),
+	}
+	encodedResult, err1 := json.Marshal(msg)
+	if err1 != nil {
 		log.WithFields(log.Fields{
+			"action":     "_handleError:Marshal",
 			"id":         id,
 			"image":      img,
 			"constraint": constraint,
 			"tagPrefix":  tagPrefix,
 			"error":      err,
 		}).Error("worker.ProcessJob")
+		return
+	}
+	if err2 := w.db.SetEvaluation(id, encodedResult, fmt.Sprint(http.StatusInternalServerError)); err2 != nil {
+		log.WithFields(log.Fields{
+			"action":     "_handleError:SetEvaluation",
+			"id":         id,
+			"image":      img,
+			"constraint": constraint,
+			"tagPrefix":  tagPrefix,
+			"error":      err,
+		}).Error("worker.ProcessJob")
+	}
+
+}
+
+func (w *BackgroundWorker) ProcessJob(ctx context.Context, id, img, constraint, tagPrefix string) error {
+	image, err := fresh_container.NewImage(img, tagPrefix)
+	if err != nil {
+		w._handleError(ctx, tagPrefix, id, img, constraint, "NewImage", err)
 		return err
 	}
 
 	// reach to external registry to fetch tags
 	if err = image.FetchTags(ctx, w.config); err != nil {
-		log.WithFields(log.Fields{
-			"id":         id,
-			"image":      img,
-			"constraint": constraint,
-			"tagPrefix":  tagPrefix,
-			"error":      err,
-		}).Error("worker.ProcessJob")
+		w._handleError(ctx, tagPrefix, id, img, constraint, "FetchTags", err)
 		return err
 	}
 
@@ -39,13 +68,7 @@ func (w *BackgroundWorker) ProcessJob(ctx context.Context, id, img, constraint, 
 		tagsString = append(tagsString, tag.String())
 	}
 	if err = w.db.SetImageTags(image, tagsString); err != nil {
-		log.WithFields(log.Fields{
-			"id":         id,
-			"image":      img,
-			"constraint": constraint,
-			"tagPrefix":  tagPrefix,
-			"error":      err,
-		}).Error("worker.ProcessJob")
+		w._handleError(ctx, tagPrefix, id, img, constraint, "save_tags", err)
 		return err
 	} else {
 		log.WithFields(log.Fields{
@@ -60,36 +83,18 @@ func (w *BackgroundWorker) ProcessJob(ctx context.Context, id, img, constraint, 
 
 	evaluation, err := image.EvalUpgrade(constraint)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"id":         id,
-			"image":      img,
-			"constraint": constraint,
-			"tagPrefix":  tagPrefix,
-			"error":      err,
-		}).Error("worker.ProcessJob")
+		w._handleError(ctx, tagPrefix, id, img, constraint, "EvalUpgrade", err)
 		return err
 	}
 
 	encodedResult, err := json.Marshal(evaluation)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"id":         id,
-			"image":      img,
-			"constraint": constraint,
-			"tagPrefix":  tagPrefix,
-			"error":      err,
-		}).Error("worker.ProcessJob")
+		w._handleError(ctx, tagPrefix, id, img, constraint, "Marshal", err)
 		return err
 	}
 
-	if err = w.db.SetEvaluation(id, encodedResult); err != nil {
-		log.WithFields(log.Fields{
-			"id":         id,
-			"image":      img,
-			"constraint": constraint,
-			"tagPrefix":  tagPrefix,
-			"error":      err,
-		}).Error("worker.ProcessJob")
+	if err = w.db.SetEvaluation(id, encodedResult, ""); err != nil {
+		w._handleError(ctx, tagPrefix, id, img, constraint, "SetEvaluation", err)
 		return err
 	}
 

--- a/pkg/fresh_container/comparer.go
+++ b/pkg/fresh_container/comparer.go
@@ -18,17 +18,17 @@ func NextTag(curTag, constraint, tagPrefix string, tags []string) (string, error
 		return "", err
 	}
 
-	versions, err := TagsToVersions(tags, tagPrefix, false)
+	versions, err := TagsToVersions(tags, tagPrefix, false, true)
 	if err != nil {
 		return "", err
 	}
 
-	nextVer := NextVersion(curVer, constraintRange, tagPrefix, versions)
+	nextVer := NextVersion(curVer, constraintRange, versions)
 
-	return tagPrefix+nextVer.String(), nil
+	return tagPrefix + nextVer.String(), nil
 }
 
-func NextVersion(curVer semver.Version, constraintRange semver.Range, tagPrefix string, versions semver.Versions) semver.Version {
+func NextVersion(curVer semver.Version, constraintRange semver.Range, versions semver.Versions) semver.Version {
 	nextVer := curVer
 	for _, v := range versions {
 		if constraintRange(v) {

--- a/pkg/fresh_container/comparer.go
+++ b/pkg/fresh_container/comparer.go
@@ -25,7 +25,7 @@ func NextTag(curTag, constraint, tagPrefix string, tags []string) (string, error
 
 	nextVer := NextVersion(curVer, constraintRange, tagPrefix, versions)
 
-	return nextVer.String(), nil
+	return tagPrefix+nextVer.String(), nil
 }
 
 func NextVersion(curVer semver.Version, constraintRange semver.Range, tagPrefix string, versions semver.Versions) semver.Version {

--- a/pkg/fresh_container/comparer_test.go
+++ b/pkg/fresh_container/comparer_test.go
@@ -118,7 +118,7 @@ func TestNextTag(t *testing.T) {
 				"alpine-2.0.3",
 			},
 			TagPrefix:   "alpine-",
-			ExpectedTag: "1.5.6",
+			ExpectedTag: "alpine-1.5.6",
 		},
 		NextTagTestCase{
 			CurTag:     "1.3.1",
@@ -132,7 +132,7 @@ func TestNextTag(t *testing.T) {
 				"alpine-2.0.3",
 			},
 			TagPrefix:   "alpine-",
-			ExpectedTag: "1.3.1",
+			ExpectedTag: "alpine-1.3.1",
 		},
 	}
 

--- a/pkg/fresh_container/image.go
+++ b/pkg/fresh_container/image.go
@@ -57,6 +57,7 @@ func NewImage(image, tagPrefix string) (Image, error) {
 // The tags are automatically converted to semver.Version objects
 // and stored into the `TagVersions` field.
 // Note well: invalid tags are going to be ignored.
+// and only tags matching the prefix if there is one are included
 func (image *Image) FetchTags(ctx context.Context, cfg *config.Config) error {
 	var err error
 
@@ -105,7 +106,7 @@ func (image *Image) EvalUpgrade(constraint string) (ImageUpgradeEvaluationRespon
 		TagPrefix:      image.TagPrefix,
 		Stale:          nextVer.GT(image.TagVersion),
 		CurrentVersion: image.Tag,
-		NextVersion:    nextVer.String(),
+		NextVersion:    image.TagPrefix+nextVer.String(),
 	}, nil
 }
 

--- a/pkg/fresh_container/image.go
+++ b/pkg/fresh_container/image.go
@@ -73,13 +73,13 @@ func (image *Image) FetchTags(ctx context.Context, cfg *config.Config) error {
 	}
 	sort.Strings(tags)
 
-	return image.SetTagVersions(tags, true)
+	return image.SetTagVersions(tags, true, false) // prefixes will be stripped on this call
 }
 
-func (image *Image) SetTagVersions(tags []string, skipInvalid bool) error {
+func (image *Image) SetTagVersions(tags []string, skipInvalid bool, prefixAlreadyStripped bool) error {
 	var err error
 
-	image.TagVersions, err = TagsToVersions(tags, image.TagPrefix, skipInvalid)
+	image.TagVersions, err = TagsToVersions(tags, image.TagPrefix, skipInvalid, prefixAlreadyStripped)
 	return err
 }
 
@@ -96,7 +96,6 @@ func (image *Image) EvalUpgrade(constraint string) (ImageUpgradeEvaluationRespon
 	nextVer := NextVersion(
 		image.TagVersion,
 		constraintRange,
-		image.TagPrefix,
 		image.TagVersions,
 	)
 
@@ -106,7 +105,7 @@ func (image *Image) EvalUpgrade(constraint string) (ImageUpgradeEvaluationRespon
 		TagPrefix:      image.TagPrefix,
 		Stale:          nextVer.GT(image.TagVersion),
 		CurrentVersion: image.Tag,
-		NextVersion:    image.TagPrefix+nextVer.String(),
+		NextVersion:    image.TagPrefix + nextVer.String(),
 	}, nil
 }
 

--- a/pkg/fresh_container/tags.go
+++ b/pkg/fresh_container/tags.go
@@ -22,9 +22,10 @@ import (
 //  return tags, nil
 //}
 
-func TagsToVersions(tags []string, tagPrefix string, skipInvalid bool) (versions semver.Versions, err error) {
+func TagsToVersions(tags []string, tagPrefix string, skipInvalid bool, prefixAlreadyStripped bool) (versions semver.Versions, err error) {
 	for _, tag := range tags {
-		if tagPrefix == "" || strings.HasPrefix(tag, tagPrefix) { // only consider tags that have the specified prefix
+		if prefixAlreadyStripped || tagPrefix == "" || strings.HasPrefix(tag, tagPrefix) {
+			// only consider tags that have the specified prefix
 			tag = strings.TrimPrefix(tag, tagPrefix)
 			v, err := semver.Parse(tag)
 			if err == nil {


### PR DESCRIPTION
Hi Flavio –

As I am deploying fresh-container to new cases, I found and fixed several problems with the initial implementation:

• using it directly worked fine, but the server mode didn't work correctly - the code paths were different and I didn't realize that initially.
• registering the handler twice trick wasn't deterministic - sometimes you would get the correct handler, sometimes you wouldn't.  I changed the way this is addressed
• if you issued queries against the same image both with a prefix and without a prefix, you got incorrect results because the values collided in the in-memory cache
• finally I changed the semantics of the return value when a tagPrefix is present to include the prefix. This makes more sense because that is what the client will have to use to pull the new image

Thanks!